### PR TITLE
YouTube RSS Export: Fix TrustedHTML for Firefox

### DIFF
--- a/youtubeRSSExport/README.md
+++ b/youtubeRSSExport/README.md
@@ -30,6 +30,8 @@ If you get an invalid OPML file or are missing subscriptions that you expect, pl
   * Switch to using the manage subscriptions page instead of the sidebar, as that loads everything up front and seems more stable.
 * 1.9 (1/30/25)
   * Fix TrustedHTML compatibility issue (so this script will work again in Chrome/Edge 83).
+* 1.10 (3/19/25)
+  * Fix TrustedHTML compatibility issue (so this script will work again in Firefox).
 
 ---
 

--- a/youtubeRSSExport/youtubeRSSExport.user.js
+++ b/youtubeRSSExport/youtubeRSSExport.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Export YouTube Subscriptions to RSS OPML
 // @namespace    https://github.com/theborg3of5/Userscripts/
-// @version      1.9
+// @version      1.10
 // @description  Adds the option to export subscriptions from YouTube as an OPML file of RSS feeds.
 // @author       Gavin Borg
 // @match        https://www.youtube.com/feed/channels
@@ -75,12 +75,14 @@ function buildXML(channels) {
    var title = xmlDoc.createElement("title");
 
    if (window.trustedTypes && window.trustedTypes.createPolicy) {
-    window.trustedTypes.createPolicy('default', {
-        createHTML: (string, sink) => string
-    });
+     window.trustedTypes.createPolicy('default', {
+       createHTML: (string, sink) => string
+     });
+     title.innerHTML = window.trustedTypes.defaultPolicy.createHTML("YouTube Subscriptions as RSS");
+   } else {
+     title.innerHTML = "YouTube Subscriptions as RSS";
    }
-   title.innerHTML = window.trustedTypes.defaultPolicy.createHTML("YouTube Subscriptions as RSS");
-   
+
    head.appendChild(title);
    opml.appendChild(head);
 


### PR DESCRIPTION
Fix #21.

I don't have Chrome installed to test it there, but I did my best to
preserve the compatibility with TrustedHTML.